### PR TITLE
Put word under cursor inside inputbox

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,19 +7,8 @@ export async function activate(context: vscode.ExtensionContext) {
     let registration = vscode.workspace.registerTextDocumentContentProvider("manvs", provider);
 
     let manPage = vscode.commands.registerCommand('manvs.man', async () => {
-        let cmd = await vscode.window.showInputBox();
-        if(cmd == undefined)
-            return;
-
-        cmd = cmd.trim();
-        if(cmd == "")
-            return;
-
-        await provider.update(`man ${cmd} | col -b`);
-
-        return vscode.commands.executeCommand('vscode.previewHtml', vscode.Uri.parse('manvs://authority/manvs'), vscode.ViewColumn.Active, `MAN ${cmd}`).then(_ => {}, _ => {
-            vscode.window.showErrorMessage("Can't open man page.");
-        });
+        let cmd = await vscode.window.showInputBox(provider.getCursorSelection());
+        provider.displayMan(cmd);
     });
 
     context.subscriptions.push(registration, manPage);


### PR DESCRIPTION
In order to have faster lookup for man pages I've slightly modified the code to automatically add the word under cursor in the input box.
This will help in faster lookup for man pages.
Looking up man-pages while writing shell script or c-programs (c library function has man pages) becomes faster.
I hope this will make the extension better.
Thanks for writing this extension.